### PR TITLE
Add result to emitter

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -170,7 +170,7 @@ IvonaRequest.prototype = {
                     }
                 }
                 data = null;
-                req.emit('end');
+                req.emit('end', res);
             });
 
             res.on('error', function(err) {


### PR DESCRIPTION
Provide the result on end. Currently if streaming, the only way to see if it was successful is to look at the content, which sort of defeats the purpose of streaming. By emitting the result of the request, e.g statusCode one can clean up if the request was invalid. (Currently Authentication Failed etc will be written through the stream).

Another way to solve this would be to emit error, however, then it may be confusing if it was caused by a connection error or service error.